### PR TITLE
Recover panics, handle cancelled context  and closed gate

### DIFF
--- a/workgate/example_test.go
+++ b/workgate/example_test.go
@@ -1,4 +1,4 @@
-//nolint: goconst // using consts in examples makes them harder to read
+// nolint: goconst // using consts in examples makes them harder to read
 package workgate
 
 import "fmt"
@@ -19,11 +19,17 @@ func ExampleWorkGate_Do() {
 func ExampleWorkGate_DoAsync() {
 	wg := New(10)
 	done := make(chan struct{})
-	wg.DoAsync(func() {
-		// Do some work (async)
-		fmt.Println("foo")
-		close(done)
-	})
+	wg.DoAsync(
+		func() {
+			// Do some work (async)
+			fmt.Println("foo")
+			close(done)
+		},
+		func(err error) {
+			fmt.Println(err)
+			close(done)
+		},
+	)
 	<-done
 	// Output: foo
 }
@@ -34,9 +40,12 @@ func ExampleWorkGate_TryDo() {
 	// Make sure the gate is full
 	free := make(chan struct{})
 	for i := 0; i < 10; i++ {
-		wg.DoAsync(func() {
-			<-free
-		})
+		wg.DoAsync(
+			func() {
+				<-free
+			},
+			nil,
+		)
 	}
 	defer close(free)
 

--- a/workgate/workgate_test.go
+++ b/workgate/workgate_test.go
@@ -219,21 +219,21 @@ func TestResourceGateDoAsyncContextRecoverWithError(t *testing.T) {
 func TestResourceGateDoAsyncContextCanceledContext(t *testing.T) {
 	gate := New(50)
 	ctx, cancel := context.WithCancel(context.Background())
-	var c atomic.Int32
-	var e atomic.Int32
+	var c int32
+	var e int32
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		gate.DoAsyncContext(ctx,
 			func() {
 				time.Sleep(100 * time.Millisecond)
-				c.Add(1)
+				atomic.AddInt32(&c, 1)
 				wg.Done()
 			},
 			func(err error) {
 				assert.Equal(t, err, errors.New("context canceled"))
-				c.Add(1)
-				e.Add(1)
+				atomic.AddInt32(&c, 1)
+				atomic.AddInt32(&e, 1)
 				wg.Done()
 			},
 		)
@@ -241,8 +241,8 @@ func TestResourceGateDoAsyncContextCanceledContext(t *testing.T) {
 	cancel()
 
 	wg.Wait()
-	assert.EqualValues(t, 100, c.Load())
-	assert.GreaterOrEqual(t, e.Load(), int32(1))
+	assert.EqualValues(t, 100, c)
+	assert.GreaterOrEqual(t, e, int32(1))
 }
 
 func TestResourceGateDoAsyncGateClosed(t *testing.T) {


### PR DESCRIPTION
We want to recover panics from goroutines. I also added error handling for cancelled context and if the gate was previously closed