### PR TITLE
.github/workflows: complete dependent-issues permissions and ignore dependabot

### DIFF
--- a/.github/workflows/dependent_pr.yml
+++ b/.github/workflows/dependent_pr.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      statuses: write
     if: github.repository_owner == 'axiomhq' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     steps:
       - uses: z0al/dependent-issues@950226e7ca8fc43dc209a7febf67c655af3bdb43 # v1
@@ -32,3 +33,4 @@ jobs:
         with:
           label: dependent
           keywords: depends on, blocked by, needs
+          ignore_dependabot: "on"


### PR DESCRIPTION
## Why

`.github/workflows/dependent_pr.yml` ran the `z0al/dependent-issues` action's cleanup path on every PR, and every cleanup failed with:

```
##[error]HttpError: Resource not accessible by integration
```

Two distinct issues, both rooted in the workflow's `permissions:` block being incomplete after #15:

1. The cleanup path calls `repos.createCommitStatus`, which needs `statuses: write`. The job declared `contents: read`, `issues: write`, `pull-requests: write` — no `statuses: write`. This broke the action on every PR, not just Dependabot ones (verified on a non-Dependabot test run).
2. Even with full permissions declared, `pull_request`-triggered runs from Dependabot get a forced read-only `GITHUB_TOKEN` (GitHub policy, not toggleable via repo settings). The action itself ships an `ignore_dependabot: on` flag for exactly this case, with the README noting: *"Use this if you run the action on `pull_request` rather than `pull_request_target`."*

## What

In `.github/workflows/dependent_pr.yml`:
- Add `statuses: write` to the `check` job's `permissions:` block
- Set `ignore_dependabot: "on"` in the action's `with:` block

## Alignment with #15

Both changes preserve #15's hardening:
- `pull_request` trigger: kept
- Pinned action SHAs: kept
- Explicit `permissions:` block: kept; only adds the missing scope the action documents needing (least privilege preserved — no `write-all`)
- Fork-PR guard: kept
- No new actions or workflows introduced
